### PR TITLE
Ignore files and directories starting with an underscore

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function generator(locals) {
   function read(root) {
     var files = fs.readdirSync(root);
     files.forEach(function (file) {
-      if (file[0] === '.') {
+      if (file[0] === '.' || file[0].startsWith('_')) {
         return;
       }
       var filepath = path.join(root, file);


### PR DESCRIPTION
Hi, thanks for the plugin, it works great !

But I have full JS applications in my static folder, with node_modules, webpack config and source, and I think it's better to put that in an underscored directory and just output the generated files in the parent directory. Example :
```
static
`-- js
    `-- my-app
        |-- dist
        |   `-- my-app.js
        `-- _app
            |-- src
            |-- node_modules
            `-- webpack.config.js
```

Plus it follows hexo convention : underscore prefix === ignore !

Thanks for reading